### PR TITLE
Fix for potentially dangerous code

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -129,11 +129,11 @@ class UltraPixelProcess:
                 "model": ("ULTRAPIXELMODEL",),
                 "height": (
                     "INT",
-                    {"default": 2048, "min": 512, "max": 5120, "step": 256},
+                    {"default": 2048, "min": 512, "max": 5120, "step": 8},
                 ),
                 "width": (
                     "INT",
-                    {"default": 2048, "min": 512, "max": 5120, "step": 256},
+                    {"default": 2048, "min": 512, "max": 5120, "step": 8},
                 ),
                 "seed": ("INT", {"default": 0, "min": 0, "max": 0xFFFFFFFFFFFFFFFF}),
                 "dtype": (["bf16", "fp32"],),

--- a/ultrapixel.py
+++ b/ultrapixel.py
@@ -144,11 +144,6 @@ class UltraPixel:
 
         captions = [self.prompt]
         height, width = self.height, self.width
-
-        """sdd = torch.load(self.pretrained, map_location="cpu") # this is the old code for loading serialized pytorch binaries (unsafe). kept it here for reference. they had a misleading file extension: ".safetensors".
-        collect_sd = {}
-        for k, v in sdd.items():
-            collect_sd[k[7:]] = v"""
             
         sdd = load_safetensors(self.pretrained) # this is the equivalent code for loading the real safetensors versions of ultrapixel_t2i and lora_cat.
         collect_sd = {k: v for k, v in sdd.items()}
@@ -163,8 +158,8 @@ class UltraPixel:
                 load_or_fail(self.controlnet), strict=True
             )
 
-        models.generator.eval()
-        models.train_norm.eval()
+        models.generator.eval()   # stage C
+        models.train_norm.eval()  # stage UP
 
         batch_size = 1
         edge_image = None

--- a/ultrapixel.py
+++ b/ultrapixel.py
@@ -16,6 +16,7 @@ from .gdf import (
 )
 from .train import WurstCore_t2i as WurstCoreC
 
+from safetensors.torch import load_file as load_safetensors
 
 class UltraPixel:
     def __init__(
@@ -88,6 +89,9 @@ class UltraPixel:
         self.prompt = prompt
         self.controlnet_image = controlnet_image
 
+
+
+
     def process(self):
         device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         torch.manual_seed(self.seed)
@@ -141,10 +145,15 @@ class UltraPixel:
         captions = [self.prompt]
         height, width = self.height, self.width
 
-        sdd = torch.load(self.pretrained, map_location="cpu")
+        """sdd = torch.load(self.pretrained, map_location="cpu") # this is the old code for loading serialized pytorch binaries (unsafe). kept it here for reference. they had a misleading file extension: ".safetensors".
         collect_sd = {}
         for k, v in sdd.items():
-            collect_sd[k[7:]] = v
+            collect_sd[k[7:]] = v"""
+            
+        sdd = load_safetensors(self.pretrained) # this is the equivalent code for loading the real safetensors versions of ultrapixel_t2i and lora_cat.
+        collect_sd = {k: v for k, v in sdd.items()}
+        collect_sd = {k[7:] if k.startswith('module.') else k: v for k, v in collect_sd.items()}
+        models.train_norm.load_state_dict(collect_sd)
 
         if self.controlnet_image == None:
             models.train_norm.load_state_dict(collect_sd)


### PR DESCRIPTION
The "safetensors" files provided for UltraPixel (ultrapixel_t2i.safetensors, lora_cat.safetensors) were not actually safetensors files at all. They were pytorch saves - potentially dangerous binaries - that misleadingly were named with the ".safetensors" extension. I converted both of them to legitimate safetensors files (links below). The changes here implement the ability to load these safetensor versions, in place of the pytorch saves.

https://huggingface.co/ClownsharkBatwing/ultrapixel_convert/blob/main/ultrapixel_t2i.safetensors
https://huggingface.co/ClownsharkBatwing/lora_cat_convert/blob/main/lora_cat.safetensors
